### PR TITLE
Bump SDK version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = ">=3.6.1,<3.9"
 requests = "^2.25.1"
-singer-sdk = "0.1.3-dev.1210880876"
+singer-sdk = "^0.3.1"
 boto3 = "^1.17.64"
 pyathena = "^2.2.0"
 


### PR DESCRIPTION
Missed from #19 was the version bump in the toml config file.